### PR TITLE
Updating outdated (and broken) underscore.js dependency reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     </script>
 
     <!-- underscore -->
-    <script src="https://fastcdn.org/Underscore.js/1.8.3/underscore-min.js">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.9.1/underscore-min.js">
     </script>
 
     <!-- jquery -->


### PR DESCRIPTION
This PR fixes BIOLITMAP (http://socialanalytics.bsc.es/biolitmap/), as it turns out that the underscore.js dependency URL is broken.

The fix is just to change one line in the index.html file.